### PR TITLE
[zh] kubeadm-init config file in beta

### DIFF
--- a/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/content/zh-cn/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -228,7 +228,7 @@ Alternatively, you can use the `skipPhases` field under `InitConfiguration`.
 <!--
 The config file is still considered beta and may change in future versions.
 -->
-配置文件的功能仍然处于 alpha 状态并且在将来的版本中可能会改变。
+配置文件的功能仍然处于 beta 状态并且在将来的版本中可能会改变。
 {{< /caution >}}
 
 <!--


### PR DESCRIPTION
seems `alpha` outdated by mistake when docs were updated, so changed it to `beta`

https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file

<!--

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will change,
 and why.

 PLEASE title the FIRST commit appropriately, so that if you squash all
 your commits into one, the combined commit message makes sense.
 For overall help on editing and submitting pull requests, visit:
  https://kubernetes.io/docs/contribute/suggesting-improvements/

 Use the default base branch, “main”, if you're documenting existing
 features in the English localization.

 If you're working on a different localization (not English), see
 https://kubernetes.io/docs/contribute/new-content/overview/#choose-which-git-branch-to-use
 for advice.

 If you're documenting a feature that will be part of a future release, see
 https://kubernetes.io/docs/contribute/new-content/new-features/ for advice.

-->
